### PR TITLE
docs(pi-4): align charter to Phase 1 (MVP Core) and log entry

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -150,14 +150,14 @@ Each increment is defined by a **Charter** and tracked by a **Log**.
 
 ## 8. Roadmap Phases (high-level)
 
-- **Increment 1 – MVP Core**
+- **Phase 1 – MVP Core**
 
   - TS code nodes (linked, inline)
   - Properties from schema
   - Command log + undo/redo
   - Convex sync + projects
 
-- **Increment 2 – Planes & Libraries**
+- **Phase 2 – Planes & Libraries**
 
   - Grouping → subgraph templates
   - PIC autogen
@@ -165,20 +165,20 @@ Each increment is defined by a **Charter** and tracked by a **Log**.
   - Basic realtime collab + presence
   - Snapshots
 
-- **Increment 3 – Displays & Search**
+- **Phase 3 – Displays & Search**
 
   - Display nodes (image/scalar)
   - GLSL node runtime
   - Library search & filters
   - Roles/sharing
 
-- **Increment 4 – Attachments & Upgrades**
+- **Phase 4 – Attachments & Upgrades**
 
   - Attachment modes (forked, baked, inline)
   - Upgrade/remap wizard
   - Overrides
 
-- **Increment 5 – Publishing & Telemetry**
+- **Phase 5 – Publishing & Telemetry**
   - Public libraries + publishing
   - Advanced telemetry (perf, audit)
   - MCP agent tools

--- a/docs/increments/pi-4/charter.md
+++ b/docs/increments/pi-4/charter.md
@@ -1,77 +1,89 @@
-# Increment Charter – PI-4
+# Increment Charter – PI-4 (Phase 1 – MVP Core)
 
 ## Context Capsule
 
-- Aim: Progress Code Node to a shippable state with safe runtime preview and initial codegen integration while polishing click→click UX.
-- Constraints/Guardrails: Preserve determinism, type safety, and adapter/IR contracts. Keep editor QoL scoped.
+- Aim: Ship the MVP Core outlined in ARCHITECTURE.md Phase 1 — TS code nodes (linked/inline), schema-driven Properties, command log with undo/redo, and Convex-backed projects (create/save/load).
+- Constraints/Guardrails: Deterministic behavior, type safety, accessibility, and adherence to command-first architecture. Keep scope tight to MVP Core.
 
 ## Focus (What we ship)
 
-- Minimal shippable Code Node: evaluate function safely, dynamic input sockets from signature (primitives), output port wired; integrate into codegen minimally.
+- A minimal end-to-end slice: create a project → insert basic nodes → wire connections → see live preview → undo/redo via command log → export deterministic TSX → save/load project via Convex.
 
 ## Prioritized Acceptance Criteria (Cornerstones)
 
-- [ ] Safe runtime preview executes user function with timeout and error capture
-- [ ] Dynamic input sockets derived from function params (primitives) refresh on code change
-- [ ] Emitted TSX includes Code Node output wiring and typechecks (noEmit)
-- [ ] Click→click chooser stable with tests in PW runner
+- [ ] TS code nodes support linked and inline attachments; nodes have typed inputs/outputs
+- [ ] Properties Panel auto-renders controls from node schema; updates reflect in preview within 100ms
+- [ ] Command log records core ops (create/select/connect/setProp/delete) with undo/redo
+- [ ] Convex projects API supports create/save/load round-trip for a single-module project
+- [ ] Deterministic TSX emitter produces stable output for identical IR
 
 ## Efforts
 
-- Effort: Sandbox Runtime
+- Effort: Node Graph Essentials
 
   - Tasks:
-    - [ ] Timeout/abort controller; error surface
-    - [ ] Deterministic execution with provided inputs
+    - [ ] Create/select node; connect edges with `targetHandle`
+    - [ ] Ensure hidden inputs unless connected; generic input optional
   - ACs:
-    - [ ] No UI freeze; errors captured
-  - Tests (TDD): Timeout/error tests
-  - Steps: wrapper → scheduler → UI
+    - [ ] Core graph interactions stable and accessible
+  - Tests (TDD): Playwright specs for selection/connect; unit tests for IR ops
+  - Steps: event wiring → state updates → a11y hooks
   - Estimate: M
   - Status: Not started
 
-- Effort: Dynamic Sockets from Signature (Primitives)
+- Effort: Properties from Schema
 
   - Tasks:
-    - [ ] Integrate parser into node definition → target handles
-    - [ ] Refresh sockets on code change; persist params
+    - [ ] Schema-driven field rendering (sliders, color, selects)
+    - [ ] Bind props → viewport updates
   - ACs:
-    - [ ] Inputs match signature; invalid types blocked
-  - Tests (TDD): parser integration; snapshots
-  - Steps: parse → normalize → apply
+    - [ ] Controls reflect schema and persist to IR; preview updates in ≤100ms
+  - Tests (TDD): unit tests for schema mapping; UI presence tests
+  - Steps: schema map → component bindings → debounce/update
   - Estimate: M
   - Status: Not started
 
-- Effort: Codegen Integration (Minimal)
+- Effort: Command Log + Undo/Redo
 
   - Tasks:
-    - [ ] Emit function and wire output prop
-    - [ ] Ensure imports/types only when referenced
+    - [ ] Log create/select/connect/setProp/delete
+    - [ ] Deterministic undo/redo
   - ACs:
-    - [ ] tsc noEmit passes
-  - Tests (TDD): snapshot + typecheck
-  - Steps: emitter ext → imports → typecheck
+    - [ ] Any sequence of logged ops can be undone/redone without corruption
+  - Tests (TDD): op invariants; undo/redo round-trips; snapshot of IR
+  - Steps: command dispatcher → log storage → reducers → history
+  - Estimate: M
+  - Status: Not started
+
+- Effort: Convex Sync + Projects
+
+  - Tasks:
+    - [ ] Mutations for create/save/load project
+    - [ ] Deterministic JSON serialization
+  - ACs:
+    - [ ] Save→Load round-trip preserves IR and module state
+  - Tests (TDD): save/load unit; minimal e2e
+  - Steps: schema → mutations/queries → client wiring
   - Estimate: S
   - Status: Not started
 
-- Effort: Click→Click UX hardening
+- Effort: Deterministic Codegen (TSX)
+
   - Tasks:
-    - [ ] E2E stabilization under Playwright
-    - [ ] Outside-click cancel and focus handling
+    - [ ] Minimal React/R3F emitter with fenced regions
+    - [ ] `tsc --noEmit` typecheck on output
   - ACs:
-    - [ ] Specs pass in CI
-  - Tests (TDD): Playwright specs
-  - Steps: event cleanup → overlay focus
+    - [ ] Identical IR yields identical TSX
+  - Tests (TDD): TSX snapshot; typecheck script
+  - Steps: tree walk → JSX emit → imports → snapshot
   - Estimate: S
   - Status: Not started
 
 ## Scope Fence (Out of Scope)
 
-- Advanced editor QoL (formatting, folding, search)
-- Non-primitive type extraction
-- Multi-file modules and external imports
+- Advanced editor QoL (formatting/folding), realtime multi-user collaboration, advanced adapters, Code Node runtime preview, and non-MVP plane/library features.
 
 ## Exit Criteria
 
-- All ACs above satisfied; demoable end-to-end with Code Node producing a value consumed by another node.
+- All ACs satisfied; tests pass; demo shows create→wire→preview→undo/redo→export→save/load end-to-end.
 - Status: In progress

--- a/docs/increments/pi-4/log.md
+++ b/docs/increments/pi-4/log.md
@@ -76,3 +76,14 @@ CI lint softening and pnpm preference rule.
 - Issues/Risks: Lint errors still present; follow-up to fix or tune rules
 - Learnings: Minimal CI friction helps land infra changes faster
 - Tests/Artifacts: CI re-run pending
+
+## Entry 8
+
+Realigned PI-4 Charter to Phase 1 (MVP Core) per ARCHITECTURE.md; created branch for work.
+
+- Action: Updated `docs/increments/pi-4/charter.md` to Phase 1 scope; created branch `feat/pi-4-charter-phase-1`
+- Files/Areas: `docs/increments/pi-4/charter.md`
+- Decisions: Focus PI-4 on MVP Core: nodes, properties, command log, Convex projects, deterministic codegen
+- Issues/Risks: Scope creep into Code Node runtime preview avoided; reserved for later phase
+- Learnings: Aligning with ARCHITECTURE phases clarifies acceptance criteria
+- Tests/Artifacts: Charter updated; follow-up to add tests per efforts


### PR DESCRIPTION
# Increment

- ID: **pi-4** (Current)
- Charter: /docs/increments/pi-4/charter.md
- Effort: `<effort-name>` (link to Charter section)

## What & Why

- Brief (1–2 sentences):

### Acceptance Criteria (from Charter)

- [ ] AC-1:
- [ ] AC-2:

### Tests (TDD)

- New tests added:
    - [ ] unit:
    - [ ] golden:
    - [ ] PIC snapshot:
    - [ ] e2e smoke:

### Docs

- [ ] Increment Log updated: /docs/increments/pi-4/log.md
- [ ] Charter Effort status updated

### Risk & Rollback

- Risk:
- Rollback: revert commit `<sha>`; feature flagged? yes/no

> Add label **include-in-preview** to include this PR in `preview/pi-4`.