### PR TITLE
docs(rules): trunk-preview – integrate Graphite stacked PR workflow

### DIFF
--- a/.cursor/rules/trunk-preview.mdc
+++ b/.cursor/rules/trunk-preview.mdc
@@ -10,10 +10,23 @@
 - Target `main`. Use the PR template; link Charter & Log.
 - Apply labels on PRs: `include-in-preview` and optionally `increment:pi-<n>`.
 
+### Stacked PRs with Graphite
+
+- Use Graphite (gt) for stacked PRs:
+  - `gt create -m "feat(pi-<n>): <scope>"` to create focused PRs (100–400 LOC)
+  - Keep PRs draft until green; merge bottom-up frequently
+  - Top PR shows the cumulative diff for quick integration review
+- Submission:
+  - `gt submit --no-interactive` (drafts) and add labels via `gh pr edit <num> --add-label include-in-preview --add-label increment:pi-<n>`
+- Restacking:
+  - `gt restack` when `main` moves; fix conflicts at the lowest PR possible
+- Charter/Log:
+  - Update `docs/increments/pi-<n>/charter.md` status and append IL entries in each PR
+
 ## Preview
 
 - Do not push directly to `preview/*`. Only automation updates preview branches.
-- To compose the preview branch, run the GitHub workflow:
+- To compose the preview branch across many small PRs, run the GitHub workflow:
   - Terminal: `gh workflow run "Build Preview Integration Branch" -f increment=pi-3 -f include_label=include-in-preview`
   - Or use the Actions UI and set `increment=pi-3`.
 


### PR DESCRIPTION
# Increment

- ID: **pi-4** (Current)
- Charter: /docs/increments/pi-4/charter.md
- Effort: `<effort-name>` (link to Charter section)

## What & Why

- Brief (1–2 sentences):

### Acceptance Criteria (from Charter)

- [ ] AC-1:
- [ ] AC-2:

### Tests (TDD)

- New tests added:
    - [ ] unit:
    - [ ] golden:
    - [ ] PIC snapshot:
    - [ ] e2e smoke:

### Docs

- [ ] Increment Log updated: /docs/increments/pi-4/log.md
- [ ] Charter Effort status updated

### Risk & Rollback

- Risk:
- Rollback: revert commit `<sha>`; feature flagged? yes/no

> Add label **include-in-preview** to include this PR in `preview/pi-4`.