### PR TITLE
feat(pi-4): Properties from schema – set effort In progress and scaffold

### DIFF
--- a/docs/increments/pi-4/charter.md
+++ b/docs/increments/pi-4/charter.md
@@ -41,7 +41,7 @@
   - Tests (TDD): unit tests for schema mapping; UI presence tests
   - Steps: schema map → component bindings → debounce/update
   - Estimate: M
-  - Status: Not started
+  - Status: In progress
 
 - Effort: Command Log + Undo/Redo
 

--- a/docs/increments/pi-4/log.md
+++ b/docs/increments/pi-4/log.md
@@ -109,3 +109,14 @@ PR template streamlined for small PRs; trunk-preview rule notes added.
 - Issues/Risks: None
 - Learnings: Focused templates reduce friction when stacking many PRs
 - Tests/Artifacts: N/A
+
+## Entry 11
+
+Started "Properties from Schema" effort.
+
+- Action: Set effort status to In progress in Charter; preparing scaffold PR
+- Files/Areas: `docs/increments/pi-4/charter.md`
+- Decisions: Begin with schema→UI mapping for core types; debounce updates to preview
+- Issues/Risks: Lint rules and E2E configuration still pending; non-blocking
+- Learnings: Charter-driven status makes PR scoping clearer
+- Tests/Artifacts: Upcoming unit/UI tests for schema mapping


### PR DESCRIPTION
# PR Title

## PR Summary (Small, Focused)

- **Increment**: pi-4 | **Effort**: `<effort-name>` (link Charter section)
- **What**: 1–2 sentence summary of the change
- **Why**: brief rationale tying to Charter AC(s)

### Acceptance Criteria covered

- [ ] AC-1 (from Charter): `<short>`
- [ ] AC-2 (optional): `<short>`

### Tests

- [ ] unit: `<files/specs>`
- [ ] snapshot/golden (if applicable)
- [ ] e2e (if applicable)

### Docs & Increment Method

- [ ] Log updated: `/docs/increments/pi-4/log.md`
- [ ] Charter Effort status updated

### Risk & Rollback

- Risk: `<short>`
- Rollback: revert `<sha>`; feature flagged? yes/no

> Labels: add `include-in-preview` (and `increment:pi-4`).